### PR TITLE
Added missing case in 'flatten'

### DIFF
--- a/src/Text/PrettyPrint/Annotated/WL.hs
+++ b/src/Text/PrettyPrint/Annotated/WL.hs
@@ -841,6 +841,7 @@ flatten (FlatAlt _ y)   = y
 flatten (Cat x y)       = Cat (flatten x) (flatten y)
 flatten (Nest i x)      = Nest i (flatten x)
 flatten (Union x _)     = flatten x
+flatten (Annotate a x)  = Annotate a (flatten x)
 flatten (Column f)      = Column (flatten . f)
 flatten (Nesting f)     = Nesting (flatten . f)
 flatten (Columns f)     = Columns (flatten . f)


### PR DESCRIPTION
I realize this is a tiny PR - but it is wreaking havoc in [my annotation heavy code](https://github.com/harpocrates/language-rust). :)

This fixes #2. The test case I presented in that issue works as expected after this fix.

Any chance you could push out a new version to Hackage? Thanks!